### PR TITLE
Reduce scope of Amount by avoiding unit conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@
 
 **Author**: Ben Allen [@ben-allen](https://github.com/ben-allen)
 
+## Goals and needs
 
-# Goals and needs
+Modeling measurements with a precision is useful for any task that involves measurements from the physical world. It can also be useful for other types of measurement; for example, (measurements of) currency amounts.
 
-Modeling units of measure is useful for any task that involves measurements from the physical world. It can also be useful for other types of measurement; for example, measurements of currency amounts. 
-
-We propose to create a new object for representing measurements, for producing formatted string representations of measurements, and for converting measurements between scales.
+We propose to create a new object for representing measurements, for producing formatted string representations of measurements.
 
 Common user needs that can be addressed by a robust API for measurements include, but are not limited to:
 
@@ -19,185 +18,62 @@ Common user needs that can be addressed by a robust API for measurements include
 
 * The need to format measurements into string representations
 
-* Related to both of the above, the need to localize measurements. This can be relatively straightforward, as in the case of converting temperature measurements between Celsius and Fahrenheit, or Celsius and Kelvin. It can be more complex, though: notably, many locales represent measurements of certain types of object using mixed units
-    - For example, in the United States it is customary to represent the heights of people in feet and inches.
-
-* The need to represent and manipulate derived units, such as square meters for area and meters cubed for volume
-
-* The need to represent and manipulate compound units, such as velocity expressed in kilometers per hour or density expressed in unit of mass per unit of volume
-
 * The need to keep track of the precision of measured values. A measurement value represented with a large number of significant figures can imply that the measurements themselves are more precise than the apparatus used to take the measurement can support.
 
-* The need to represent currency values. Often users will want to keep track of money values together with the currency in which those values are denominated.
-    - As in the "feet and inches" example, sometimes it is useful to present currency values with the major and minor units separated, as in "19 dollars and 17 cents." See: [Design for currency and unit inputs that carry their values ](https://github.com/tc39/ecma402/issues/911#issuecomment-2238619851)
+## Description
 
-* The need to define custom units.
-    - For example, CLDR includes units for velocity and acceleration, but none of the higher-order derivatives of position with respect to time.
-
-# Description
-
-We propose creating a new `Measure` API, with the following properties.
+We propose creating a new `Amount` API, with the following properties.
 
 Note: ⚠️  All property/method names up for bikeshedding.
 
-* `unit`, a String representing the measurement unit. This could be expressed using the names used by [CLDR's units.xml](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml). The API design below presumes that these names are used. For example, if a user wanted to use the `convertTo` method to convert a length measurement to feet and inches, they would provide the string `"foot-and-inch"` as the value of the `unit` argument.
+* `value` (String), the numerical value of the measurement, representing an exact mathematical value;
+* `significantDigits` (Number): how many significant digits does this value contain? (Should be a positive integer)
+* `fractionalDigits` (Number): how many digits are required to fully represent the part of the fractional part of the underlying mathematical value. (Should be a non-negative integer.)
 
-* `value`, the numerical value of the measurement.
+#### Precision
 
-* `precision`, a number indicating the precision of the measurement. This precision is (provisionally) represented in terms of the number of fractional digits displayed.
+A big question is how we should handle precision. When constructing an Amount, both the significant digits and fractional digits are recorded.
 
-* `exponent`, an integer representing the power to which the unit is raised. "centimeters squared" could be {unit: "centimeter", exponent: 2}. It may be preferable to use CLDR names for commonly-used units; "cubic-meter" instead of {unit: "meter", exponent: 3}, for example.
+### Constructor
 
-* `usage`, the type of thing being measured. Useful for localization.
-
-### Precision
-A big question is how we should handle precision. Currently this explainer assumes precision means fractional 
-digits, not because it seems good but instead because it seems least-bad. [The Java Units of Measurement API](https://unitsofmeasurement.github.io/unit-api/) 
-appears to resolve this problem by not handling precision at all.
-
-## Constructor
-
-* `Measure(value, {unit, precision, exponent, usage})`. Constructs a Measure with `value` as the numerical value of the Measure and `unit` as the unit of measurement, with the optional `precision` parameter used to specify the precision of the measurement. In the case of `unit` values indicating mixed units, the `value` is given in terms of the quantity of the *largest* unit. If no unit is provided, the value of unit is `"dimensionless"`. `exponent` indicates the power to which the underlying unit is raised; `exponent` of 2 on an object with "centimeter" as the `unit` value indicates centimeter-squared.
+* `new Measure(value)`. Constructs a Measure with the digit String `value` as the numerical value of the Measure.
 
 The object prototype would provide the following methods:
 
-* `convertTo(unit, precision)`. This method returns a Measure in the scale indicated by the `unit` parameter, with the value of the new Measure being the value of the Measure it is called on converted to the new scale.
-
 * `toString()`. This method returns a string representation of the unit.
+* `with(opts)`: Represent the same underlying mathematical value, possibly with different precision.
 
-* `toComponents()`. This method returns each component of the measurement as an object in an array. Intended for use
-with mixed units.
-
-```js
-    let centimeters = new Measurement(30, {unit: "centimeter"})
-    centimeters.toString()
-    // "30 centimeters"
-
-    footAndInch.toComponents()
-    // [ {value: 5, unit: "foot"}, {value: 6, unit: "inch"}]
-```
-
-### Mixed units
-
-We absolutely must include mixed units in Measurement, because they're absolutely 
-needed for [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences). We can't just include foot-and-inch in Smart Units
-and not Measurement, since that invites specifically the type of abuse of 
-i18n tools for non-i18n purposes that we're trying to avoid with the Measure proposal
-
-The value of mixed units should be expressed in terms of the largest unit in the mixed unit. 
-(Alternately, the Measurement's value could be expressed in terms of the smallest unit. We're
-going with largest for the example below)
+### Examples
 
 ```js
-    let footAndInch = new Measurement(5.5, {unit: "foot-and-inch"})
-    footAndInch.toComponents()
-    // [ {value: 5, unit: "foot"}, {value: 6, unit: "inch"}]
-    footAndInch.toString()
-    // "5 feet and 6 inches"
+let a = new Amount("123.456");
+a.fractionDigits; // 3
+a.significantDigits; // 6
+a.with({ fractionDigits: 4 }).toString(); "123.4560"
 ```
 
+## Related but out-of-scope features
 
-## Mathematical operations
+Measure is intended to be a small, straightforwardly implementable kernel of functionality for JavaScript programmers that could perhaps be expanded upon in a follow-on proposal if data warrants. Some features that one might imagine belonging to Measure are natural and understandable, but are currently out-of scope. Here are the features:
 
-Below is a list of mathematical operations that we should consider supporting. 
-Assume that we use [CLDR data](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml) 
-for now, and that both our unit names and the conversion constants are as in CLDR.
+### Mathematical operations
 
+Below is a list of mathematical operations that one could consider supporting. However, to avoid confusion and ambiguity about the meaning of propagating precision in arithmetic operations, *we do not intend to support mathematical operations*. A natural source of data would be the [CLDR data](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml) for both our unit names and the conversion constants are as in CLDR. One could conceive of operations such as:
 
-### Proposed mathematical operations
+* raising a Measurement to an exponent
+* multiply/divide a Measurement by a scalar
+* Add/subtract two Measurements of the same dimension
+* multiply/divide a Measurement by another Measurement
+* Convert between scales (e.g., convert from grams to kilograms)
 
-Raise a Measurement to an exponent:
+could be imagined, but are out-of-scope in this proposal. This proposal focuses on on the numeric core that future proposals can build on.
 
-```js
-    let measurement = new Measurement(10, {unit: "centimeter"});
-    measurement.exp(3);
-    // { value: 1000, unit: "cubic-centimeter"}
-```
+### Units
 
-* Multiply/divide a measurement by a scalar
+One naturally might want to include units (`mile`, `kilogram`, etc.) but we currently envision that functionality being part of the [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences) proposal. This implies that converting from unit to another is not supported, as well as converting measurements between scales (e.g., converting grams to kilograms). Our work is designed to be a foundation for such ideas.
 
-```js
-    let measurement = new Measurement(10, {unit: "centimeter"});
-    measurement.multiply(20);
-    // {value: 200, unit: "centimeter"};
-    measurement.divide(10);
-    // {value: 20, unit: "centimeter"};
-```
+## Related/See also
 
-* Add/subtract two measurements of the same dimension
-
-```js
-    let measurement1 = new Measurement(10, {unit: "centimeter"});
-    let measurement2 = new Measurement(5, {unit: "centimeter"});
-    measurement1.add(measurement2);
-    // {value: 15, unit: "centimeter"}
-
-    let measurement3 = new Measurement(5, {unit: "meter"});
-    measurement1.add(measurement3);
-    // in the units of the Measurement that `add` is called on?
-    // {value: 510, unit: "centimeter"}
-
-    measurement1.subtract(measurement2);
-    // {value: 505, unit: "centimeter"}
-    
-    // Precision is given in fractional digits. If doing calculation with units with
-    // precision values, the precision should be set to the least precise (taking 
-    // into account that units will have to be converted to the same scale)
-    let measurementWithPrecision1 = new Measurement(10.12, {unit: "centimeter", precision: 2};
-    let measurementWithPrecision2 = new Measurement(10.1234 {unit: "centimeter", precision: 4};
-    measurementWithPrecision1.add(measurementWithPrecision2);;
-    // {value: 20.24, unit: "centimeter", precision: 2}
-
-```
-
-* Multiply / divide a Measurement by another Measurement 
-
-```js
-    let gallons = new Measurement(2, {unit: "gallon"});
-    let miles = new Measurement(30, {unit: "mile"});
-    miles.divide(gallon);
-    // {value: 15, unit: "miles-per-gallon"}
-
-    let centimeters1 = new Measurement(10, {unit: "centimeter"});
-    let centimeters2 = new Measurement(5, {unit: "centimeter"});
-    centimeters1.multiply(centimeters2);
-    // {value: 50, unit: "square-centimeter" }
-    // alternately: {value: 50, unit: "centimeter", exponent: 2}
-```
-
-* Convert between scales
-
-```js
-    let inches = new Measure(12, {unit: "inch"});
-    inches.convertTo("centimeter");
-    // {value: 30.48, unit: "centimeter}
-    // using optional `precision` option
-    inches.convertTo("centimeter", 1);
-    // { value: 30.5, unit: "centimeter" }
-```
-
-* All of the above operations throw if incompatible dimensions are used, for example, adding 
-a measure of volume to a measure of speed.
-
-### User-defined units
-
-Users can specify values for `unit` other than the ones we support. The only mathematical 
-operations that apply to Measurements with non-standard units are the ones involving scalars.
-
-### `convertToLocale` method shifted to Smart Units
-
-The method `convertToLocale` is shifted to Smart Units. This method can use 
-a `usage` option for Measurements in order to properly localize measurements of
-certain types of thing.
-
-* convertToLocale(locale)
-
-```js
-    let centimeters = new Measurement(30.48, {unit: "centimeter", usage: "person-height"});
-    centimeters.convertToLocale("en");
-    // {value: 5.5, unit: "foot-and-inch"}
-
-    centimeters.toLocaleString('en');
-    // "5 feet and 6 inches"
-```
-
+* [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences) (mentioned several times as a natural follow-on proposal to this one)
+* [Decimal](https://github.com/tc39/proposal-decimal) for exact decimal arithmetic
+* [Preserve trailing zeroes](https://github.com/tc39/proposal-intl-keep-trailing-zeros) to ensure that when Intl handles digit strings, it doesn't automatically strip trailing zeroes (e.g., silently normalize "1.20" to "1.2").

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ let b = new Amount("42.55", { currency: "EUR" }); // 42.55 Euros
 
 When serializing an Amount that has a unit/currency marker, units are automatically rendered in lowercase and currency always in uppercase.
 
-Note that, currently, no meaning is specified for units. You can use `"ABCDEFG"` as a currency and `"keelogramz"` as a unit.
+Note that, currently, no meaning is specified for currencies or units.
+You can use `"XYZ"` as a currency or `"keelogramz"` as a unit.
+Calling `toLocaleString()` on an Amount with a unit not supported by Intl.NumberFormat will throw an Error.
 
 
 ## Related but out-of-scope features

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Measure is intended to be a small, straightforwardly implementable kernel of fun
 
 Below is a list of mathematical operations that one could consider supporting. However, to avoid confusion and ambiguity about the meaning of propagating precision in arithmetic operations, *we do not intend to support mathematical operations*. A natural source of data would be the [CLDR data](https://github.com/unicode-org/cldr/blob/main/common/supplemental/units.xml) for both our unit names and the conversion constants are as in CLDR. One could conceive of operations such as:
 
-* raising a Measurement to an exponent
-* multiply/divide a Measurement by a scalar
-* Add/subtract two Measurements of the same dimension
-* multiply/divide a Measurement by another Measurement
+* raising an Amount to an exponent
+* multiply/divide an Amount by a scalar
+* Add/subtract two Amounts of the same dimension
+* multiply/divide an Amount by another Amount
 * Convert between scales (e.g., convert from grams to kilograms)
 
 could be imagined, but are out-of-scope in this proposal. This proposal focuses on on the numeric core that future proposals can build on.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A big question is how we should handle precision. When constructing an Amount, b
 
 ### Constructor
 
-* `new Measure(value)`. Constructs a Measure with the digit String `value` as the numerical value of the Measure.
+* `new Amount(value[, options])`. Constructs an Amount with the mathematical value of `value`, and optional `options`.
 
 The object prototype would provide the following methods:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The object prototype would provide the following methods:
   By default, returns a digit string together with the unit/currency in square brackets (e.g., `"1.23[kg]`) if the Amount does have an amount; otherwise, just the bare numeric value.
   With `options` specified (not undefined), we consult its `displayUnit` property, looking for three possible String values: `"auto"`, `"never"`, and `"always"`. With `"auto"` (the default), we do what was just described previously. With `displayUnit "never"`, we will never show the unit, even if the Amount does have one; and with `displayUnit: "always"` we will always show the unit, using `"1"` as the unit for Amounts without a unit (the "unit unit").
 
-* `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
+* `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator). The options are the same as those for `toString()` above.
 * `with(options)`: Create a new Amount based on this one,
   together with additional options.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ The object prototype would provide the following methods:
 
 * `toString([ opts ])`: Returns a string representation of the measurement with any unit put in brackets (e.g., `"1.23[kg]`).
 * `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
-* `with(opts)`: Represent the same underlying mathematical value, possibly with different precision.
+* `with(options)`: Create a new Amount based on this one,
+  together with additional options.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ A big question is how we should handle precision. When constructing an Amount, b
 The object prototype would provide the following methods:
 
 * `toString([ options ])`: Returns a string representation of the amount.
-  By default, returns a digit string.
-  With `options: 'long'`, returns a digits string together with the normalized unit or currency in square brackets (e.g., `"1.23[kg]`).
+  By default, returns a digit string together with the unit/currency in square brackets (e.g., `"1.23[kg]`).
+  With `options: 'short'`, returns a digits string only, without unit.
 * `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
 * `with(options)`: Create a new Amount based on this one,
   together with additional options.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ This implies that converting from unit to another is not supported,
 as well as converting amounts between scales (e.g., converting grams to kilograms).
 Our work here in this proposal is designed to provide a foundation for such ideas.
 
+### Compount units
+
+Some units can be combined. In the US, it is common to express the heights of people in terms of feet and inches, rather than a non-integer number of feet or a "large" number of inches. For instance, one would say commonly express a height of 71 inches as "5 feet 11 inches" rather than "71 inches" or "5.92 feet". Thus, one would naturally want to support "foot-and-inch" as a compound unit, derivable from a measurement in terms of feet or inches. Since this is closely related to unit conversion, we prefer to see this functionality in Smart Units.
+
 ## Related/See also
 
 * [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences) (mentioned several times as a natural follow-on proposal to this one)

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ One might want to convert a Measurement from one unit (e.g., miles) to another (
 
 * [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences) (mentioned several times as a natural follow-on proposal to this one)
 * [Decimal](https://github.com/tc39/proposal-decimal) for exact decimal arithmetic
-* [Preserve trailing zeroes](https://github.com/tc39/proposal-intl-keep-trailing-zeros) to ensure that when Intl handles digit strings, it doesn't automatically strip trailing zeroes (e.g., silently normalize "1.20" to "1.2").
+* [Keep trailing zeroes](https://github.com/tc39/proposal-intl-keep-trailing-zeros) to ensure that when Intl handles digit strings, it doesn't automatically strip trailing zeroes (e.g., silently normalize "1.20" to "1.2").

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ a.toString({ numberOnly: true }); // "42.7"
 
 #### Rounding
 
-If one downgrades the precision of a Measurement, rounding will occur. (Upgrading just adds trailing zeroes.)
+If one downgrades the precision of an Amount, rounding will occur. (Upgrading just adds trailing zeroes.)
 
 ```js
 let a = new Amount("123.456");

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This implies that converting from unit to another is not supported,
 as well as converting amounts between scales (e.g., converting grams to kilograms).
 Our work here in this proposal is designed to provide a foundation for such ideas.
 
-### Compount units
+### Compound units
 
 Some units can be combined. In the US, it is common to express the heights of people in terms of feet and inches, rather than a non-integer number of feet or a "large" number of inches. For instance, one would say commonly express a height of 71 inches as "5 feet 11 inches" rather than "71 inches" or "5.92 feet". Thus, one would naturally want to support "foot-and-inch" as a compound unit, derivable from a measurement in terms of feet or inches. Since this is closely related to unit conversion, we prefer to see this functionality in Smart Units.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A big question is how we should handle precision. When constructing an Amount, b
 
 The object prototype would provide the following methods:
 
-* `toString()`: Returns a string representation of the measurement with any unit put in brackets (e.g., `"1.23[kg]`).
+* `toString([ opts ])`: Returns a string representation of the measurement with any unit put in brackets (e.g., `"1.23[kg]`).
 * `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
 * `with(opts)`: Represent the same underlying mathematical value, possibly with different precision.
 
@@ -57,6 +57,14 @@ a.with({ fractionDigits: 4 }).toString(); // "123.4560"
 ```
 
 Notice that "upgrading" the precision of a Measurement essentially appends trailing zeroes to the number.
+
+Here's an example with units:
+
+```js
+let a = new Amount("42.7", { unit: "kg" });
+a.toString(); // "42.7[kg]"
+a.toString({ numberOnly: true }); // "42.7"
+```
 
 #### Rounding
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ A big question is how we should handle precision. When constructing an Amount, b
 
 The object prototype would provide the following methods:
 
-* `toString([ options ])`: Returns a string representation of the amount.
-  By default, returns a digit string together with the unit/currency in square brackets (e.g., `"1.23[kg]`).
-  With `options: 'short'`, returns a digits string only, without unit.
+* `toString([ options ])`: Returns a string representation of the Amount.
+  By default, returns a digit string together with the unit/currency in square brackets (e.g., `"1.23[kg]`) if the Amount does have an amount; otherwise, just the bare numeric value.
+  With `options` specified (not undefined), we consult its `displayUnit` property, looking for three possible String values: `"auto"`, `"never"`, and `"always"`. With `"auto"` (the default), we do what was just described previously. With `displayUnit "never"`, we will never show the unit, even if the Amount does have one; and with `displayUnit: "always"` we will always show the unit, using `"1"` as the unit for Amounts without a unit (the "unit unit").
+
 * `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
 * `with(options)`: Create a new Amount based on this one,
   together with additional options.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ a.with({ significantDigits: 5, roundingMode: "truncate" }).toString(); // "123.4
 
 ## Units
 
-A core piece of functionality for the Measure proposal is to support units (`mile`, `kilogram`, etc.) as well as currency (`EUR`, `USD`, etc.). One can construct these
+A core piece of functionality for the proposal is to support units (`mile`, `kilogram`, etc.) as well as currency (`EUR`, `USD`, etc.). One can construct these
 
 
 ## Related but out-of-scope features

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The object prototype would provide the following methods:
 
 ### Examples
 
-Let's construct a Measurement, query its properties, and render it. First, we'll work with a bare number (no unit):
+Let's construct an Amount, query its properties, and render it.
+First, we'll work with a bare number (no unit):
 
 ```js
 let a = new Amount("123.456");

--- a/README.md
+++ b/README.md
@@ -88,9 +88,18 @@ let b = new Amount("123.456");
 a.with({ significantDigits: 5, roundingMode: "truncate" }).toString(); // "123.45"
 ```
 
-## Units
+## Units (including currency)
 
-A core piece of functionality for the proposal is to support units (`mile`, `kilogram`, etc.) as well as currency (`EUR`, `USD`, etc.). One can construct these
+A core piece of functionality for the proposal is to support units (`mile`, `kilogram`, etc.) as well as currency (`EUR`, `USD`, etc.). An Amount need not have a unit/currency, and if it does, it has one or the other (not both). Example:
+
+```js
+let a = new Amount("123.456", { unit: "kg" }); // 123.456 kilograms
+let b = new Amount("42.55", { currency: "EUR" }); // 42.55 Euros
+```
+
+When serializing an Amount that has a unit/currency marker, units are automatically rendered in lowercase and currency always in uppercase.
+
+Note that, currently, no meaning is specified for units. You can use `"ABCDEFG"` as a currency and `"keelogramz"` as a unit.
 
 
 ## Related but out-of-scope features

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Below is a list of mathematical operations that one could consider supporting. H
 * multiply/divide an Amount by another Amount
 * Convert between scales (e.g., convert from grams to kilograms)
 
-could be imagined, but are out-of-scope in this proposal. This proposal focuses on on the numeric core that future proposals can build on.
+could be imagined, but are out-of-scope in this proposal.
+This proposal focuses on the numeric core that future proposals can build on.
 
 ### Unit conversion
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ could be imagined, but are out-of-scope in this proposal. This proposal focuses 
 
 ### Unit conversion
 
-One might want to convert a Measurement from one unit (e.g., miles) to another (e.g., kilometers). However, we envision that functionality as part of the [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences) proposal. This implies that converting from unit to another is not supported, as well as converting measurements between scales (e.g., converting grams to kilograms). Our work here in the Measure proposal is designed to be a foundation for such ideas.
+One might want to convert an Amount from one unit (e.g., miles) to another (e.g., kilometers).
+We envision that functionality to be potentially introduced as part of the [Smart Units](https://github.com/tc39/proposal-smart-unit-preferences) proposal.
+This implies that converting from unit to another is not supported,
+as well as converting amounts between scales (e.g., converting grams to kilograms).
+Our work here in this proposal is designed to provide a foundation for such ideas.
 
 ## Related/See also
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ We propose creating a new `Amount` API, whose values will be immutable and have 
 
 Note: ⚠️  All property/method names up for bikeshedding.
 
-* `value` (String): The numerical value of the measurement, representing an exact mathematical value;
 * `currency` (String or undefined): The currency code with which number should be understood (with *undefined* indicating "none supplied")
 * `unit` (String or undefined): The unit of measurement with which number should be understood (with *undefined* indicating "none supplied")
 * `significantDigits` (Number): how many significant digits does this value contain? (Should be a positive integer)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A big question is how we should handle precision. When constructing an Amount, b
 The object prototype would provide the following methods:
 
 * `toString()`: Returns a string representation of the measurement with any unit put in brackets (e.g., `"1.23[kg]`).
-* `toLocaleString()`: Return a string representation appropriate to the locale (e.g., `"1,23[kg]"` in locales that use a comma as a fraction separator)
+* `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
 * `with(opts)`: Represent the same underlying mathematical value, possibly with different precision.
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Common user needs that can be addressed by a robust API for measurements include
 
 * The need to keep track of the precision of measured values. A measurement value represented with a large number of significant figures can imply that the measurements themselves are more precise than the apparatus used to take the measurement can support.
 
+* The need to represent currency values. Often users will want to keep track of money values together with the currency in which those values are denominated.
+
 * The need to format measurements into string representations
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ A big question is how we should handle precision. When constructing an Amount, b
 
 ### Constructor
 
-* `new Amount(value[, options])`. Constructs an Amount with the mathematical value of `value`, and optional `options`.
+* `new Amount(value[, options])`. Constructs an Amount with the mathematical value of `value`, and optional `options`, of which the following are supported (all being optional):
+  * `currency` or `unit` (String): a marker for the measurement (cannot supply both)
+  * `fractionDigits`: the number of fractional digits the mathematical value should have (can be less than, equal to, or greater than the actual number of fractional digits that the underlying mathematical value has when rendered as a decimal digit string)
+  * `significantDigits`: the number of significant digits that the mathematical value should have  (can be less than, equal to, or greater than the actual number of significant digits that the underlying mathematical value has when rendered as a decimal digit string)
+  * `roundingMode`: one of the seven supported Intl rounding modes. This option is used when the `fractionDigits` and `significantDigits` options are provided and rounding is necessary to ensure that the value really does have the specified number of fraction/significant digits.
 
 The object prototype would provide the following methods:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We propose creating a new `Amount` API, whose values will be immutable and have 
 Note: ⚠️  All property/method names up for bikeshedding.
 
 * `value` (String): The numerical value of the measurement, representing an exact mathematical value;
+* `currency` (String or undefined): The currency code with which number should be understood (with *undefined* indicating "none supplied")
 * `unit` (String or undefined): The unit of measurement with which number should be understood (with *undefined* indicating "none supplied")
 * `significantDigits` (Number): how many significant digits does this value contain? (Should be a positive integer)
 * `fractionalDigits` (Number): how many digits are required to fully represent the part of the fractional part of the underlying mathematical value. (Should be a non-negative integer.)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ a.significantDigits; // 6
 a.with({ fractionDigits: 4 }).toString(); // "123.4560"
 ```
 
-Notice that "upgrading" the precision of a Measurement essentially appends trailing zeroes to the number.
+Notice that "upgrading" the precision of an Amount appends trailing zeroes to the number.
 
 Here's an example with units:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ A core piece of functionality for the Measure proposal is to support units (`mil
 
 ## Related but out-of-scope features
 
-Measure is intended to be a small, straightforwardly implementable kernel of functionality for JavaScript programmers that could perhaps be expanded upon in a follow-on proposal if data warrants. Some features that one might imagine belonging to Measure are natural and understandable, but are currently out-of scope. Here are the features:
+Amount is intended to be a small, straightforwardly implementable kernel of functionality for JavaScript programmers that could perhaps be expanded upon in a follow-on proposal if data warrants. Some features that one might imagine belonging to Amount are natural and understandable, but are currently out-of scope. Here are the features:
 
 ### Mathematical operations
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,13 @@ This implies that converting from unit to another is not supported,
 as well as converting amounts between scales (e.g., converting grams to kilograms).
 Our work here in this proposal is designed to provide a foundation for such ideas.
 
+### Derived units
+
+Some units can derive other units, such as square meters and cubic yards (to mention only a couple!). Support for such units is currently out-of-scope for this proposal.
+
 ### Compound units
 
-Some units can be combined. In the US, it is common to express the heights of people in terms of feet and inches, rather than a non-integer number of feet or a "large" number of inches. For instance, one would say commonly express a height of 71 inches as "5 feet 11 inches" rather than "71 inches" or "5.92 feet". Thus, one would naturally want to support "foot-and-inch" as a compound unit, derivable from a measurement in terms of feet or inches. Since this is closely related to unit conversion, we prefer to see this functionality in Smart Units.
+Some units can be combined. In the US, it is common to express the heights of people in terms of feet and inches, rather than a non-integer number of feet or a "large" number of inches. For instance, one would say commonly express a height of 71 inches as "5 feet 11 inches" rather than "71 inches" or "5.92 feet". Thus, one would naturally want to support "foot-and-inch" as a compound unit, derivable from a measurement in terms of feet or inches. Likewise, combining units to express, say, velocity (miles per hour) or density (grams per cubic centimeter) also falls under this umbrella.  Since this is closely related to unit conversion, we prefer to see this functionality in Smart Units.
 
 ## Related/See also
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 
 ## Goals and needs
 
-Modeling measurements with a precision is useful for any task that involves measurements from the physical world. It can also be useful for other types of measurement; for example, (measurements of) currency amounts.
-
-We propose to create a new object for representing measurements, for producing formatted string representations of measurements.
+Modeling amounts with a precision is useful for any task that involves physical quantities.
+It can also be useful for other types of real-world amounts, such as currencies.
+We propose creating a new object for representing amounts,
+and for producing formatted string representations thereof.
 
 Common user needs that can be addressed by a robust API for measurements include, but are not limited to:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ A big question is how we should handle precision. When constructing an Amount, b
 
 The object prototype would provide the following methods:
 
-* `toString([ opts ])`: Returns a string representation of the measurement with any unit put in brackets (e.g., `"1.23[kg]`).
+* `toString([ options ])`: Returns a string representation of the amount.
+  By default, returns a digit string.
+  With `options: 'long'`, returns a digits string together with the normalized unit or currency in square brackets (e.g., `"1.23[kg]`).
 * `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator)
 * `with(options)`: Create a new Amount based on this one,
   together with additional options.


### PR DESCRIPTION
In discussions among various TC39 delegates, it has become clear that the concept of a unit conversion brings up a number of challenges that can be cleanly separated from the more fundamental problem of representing a mathematical value, tagged with a unit, together with a precision. This is an important part of the notion of measurement that is a subset of the original motivation and argument for Measure. We propose to separate these challenges from those that come from supporting measurements, such as:

* the need for unit conversion,
* compound units (e.g., "foot-and-inch"),
* arithmetic: involved in conversions (rationals?  decimals? binary floats?),

etc.