### PR TITLE
Grant GH deploy permission to write

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy gh-pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
If I understand [this](https://github.com/JamesIves/github-pages-deploy-action) correctly, it looks like there may be a permissions issue with the recent GH deploy failure.