### PR TITLE
Drop currency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ We propose creating a new `Amount` API, whose values will be immutable and have 
 
 Note: ⚠️  All property/method names up for bikeshedding.
 
-* `currency` (String or undefined): The currency code with which number should be understood (with *undefined* indicating "none supplied")
 * `unit` (String or undefined): The unit of measurement with which number should be understood (with *undefined* indicating "none supplied")
 * `significantDigits` (Number): how many significant digits does this value contain? (Should be a positive integer)
 * `fractionalDigits` (Number): how many digits are required to fully represent the part of the fractional part of the underlying mathematical value. (Should be a non-negative integer.)
@@ -39,7 +38,7 @@ A big question is how we should handle precision. When constructing an Amount, b
 ### Constructor
 
 * `new Amount(value[, options])`. Constructs an Amount with the mathematical value of `value`, and optional `options`, of which the following are supported (all being optional):
-  * `currency` or `unit` (String): a marker for the measurement (cannot supply both)
+  * `unit` (String): a marker for the measurement
   * `fractionDigits`: the number of fractional digits the mathematical value should have (can be less than, equal to, or greater than the actual number of fractional digits that the underlying mathematical value has when rendered as a decimal digit string)
   * `significantDigits`: the number of significant digits that the mathematical value should have  (can be less than, equal to, or greater than the actual number of significant digits that the underlying mathematical value has when rendered as a decimal digit string)
   * `roundingMode`: one of the seven supported Intl rounding modes. This option is used when the `fractionDigits` and `significantDigits` options are provided and rounding is necessary to ensure that the value really does have the specified number of fraction/significant digits.
@@ -47,7 +46,7 @@ A big question is how we should handle precision. When constructing an Amount, b
 The object prototype would provide the following methods:
 
 * `toString([ options ])`: Returns a string representation of the Amount.
-  By default, returns a digit string together with the unit/currency in square brackets (e.g., `"1.23[kg]`) if the Amount does have an amount; otherwise, just the bare numeric value.
+  By default, returns a digit string together with the unit in square brackets (e.g., `"1.23[kg]`) if the Amount does have an amount; otherwise, just the bare numeric value.
   With `options` specified (not undefined), we consult its `displayUnit` property, looking for three possible String values: `"auto"`, `"never"`, and `"always"`. With `"auto"` (the default), we do what was just described previously. With `displayUnit "never"`, we will never show the unit, even if the Amount does have one; and with `displayUnit: "always"` we will always show the unit, using `"1"` as the unit for Amounts without a unit (the "unit unit").
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator). The options are the same as those for `toString()` above.
@@ -98,14 +97,14 @@ A core piece of functionality for the proposal is to support units (`mile`, `kil
 
 ```js
 let a = new Amount("123.456", { unit: "kg" }); // 123.456 kilograms
-let b = new Amount("42.55", { currency: "EUR" }); // 42.55 Euros
+let b = new Amount("42.55", { unit: "EUR" }); // 42.55 Euros
 ```
 
-When serializing an Amount that has a unit/currency marker, units are automatically rendered in lowercase and currency always in uppercase.
-
-Note that, currently, no meaning is specified for currencies or units.
-You can use `"XYZ"` as a currency or `"keelogramz"` as a unit.
+Note that, currently, no meaning is specified within Amount for units.
+You can use `"XYZ"` or `"keelogramz"` as a unit.
 Calling `toLocaleString()` on an Amount with a unit not supported by Intl.NumberFormat will throw an Error.
+Unit identifiers consisting of three upper-case ASCII letters will be formatted with `style: 'currency'`,
+while all other units will be formatted with `style: 'unit'`.
 
 
 ## Related but out-of-scope features

--- a/spec.emu
+++ b/spec.emu
@@ -24,7 +24,7 @@ location: https://github.com/tc39/proposal-measure/
   <h1>The Amount Object</h1>
   <emu-intro id="sec-amount-intro">
     <h1>Introduction</h1>
-    <p>An Amount is an object that wraps mathematical value and a precision, together with a unit (e.g., mile, kilogram) or currency (e.g., EUR, JPY, USD). One can intuitively understand an Amount as a number that, so to speak, knows its own precision and what it is measuring.</p>
+    <p>An Amount is an object that wraps mathematical value and a precision, together with a unit (e.g., mile, kilogram, EUR, JPY, USD-per-mile). One can intuitively understand an Amount as a number that, so to speak, knows its own precision and what it is measuring.</p>
     <p>The notation for mathematical values used by Amount are <dfn id="dfn-decimal-digit-string">decimal digit string</dfn>, which are Strings that adhere to the <emu-xref href="#prod-DecimalLiteral">DecimalLiteral</emu-xref> production, excepting *"NaN"*, *"Infinity", and *"-Infinity"*.</p>
     <p>Rounding a mathematical value is an important part of this spec. When we say <dfn id="dfn-amount-rounding-mode">rounding mode</dfn> in this specification we simply refer to <emu-xref href="#table-intl-rounding-modes">ECMA-402's definition</emu-xref>.</p>
   </emu-intro>
@@ -232,7 +232,7 @@ location: https://github.com/tc39/proposal-measure/
       <emu-clause id="sec-amount-getamountoptions" type="abstract operation">
         <h1>GetAmountOptions(
           _opts_: an Object
-        ): either a normal completion containing a Record with fields [[Currency]] (a String or *undefined*), [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), [[SignificantDigits]] (a positive integer or *undefined*), and [[Unit]] (a String or *undefined*) or a throw completion
+        ): either a normal completion containing a Record with fields [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), [[SignificantDigits]] (a positive integer or *undefined*), and [[Unit]] (a String or *undefined*) or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -240,12 +240,10 @@ location: https://github.com/tc39/proposal-measure/
         </dl>
         <emu-alg>
           1. Let _opts_ be ? GetOptionsObject(_opts_).
-          1. Let _currency_ be ? GetOption(_opts_, *"currency"*, ~string~, ~empty~, *undefined*).
           1. Let _fractionDigits_ be ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
           1. Let _roundingMode_ be ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
           1. Let _significantDigits_ be ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
           1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
-          1. If _currency_ is the empty String, throw a *RangeError* exception.
           1. If _fractionDigits_ is not *undefined*, then
             1. If _significantDigits_ is not *undefined*, throw a *RangeError* exception.
             1. If _fractionDigits_ is not a non-negative integral number, throw a *RangeError* exception.
@@ -253,10 +251,7 @@ location: https://github.com/tc39/proposal-measure/
             1. If _significantDigits_ is not an integral number, throw a *RangeError* exception.
             1. If ℝ(_significantDigits_) < 1, throw a *RangeError* exception.
           1. If _unit_ is the empty String, throw a *RangeError* exception.
-          1. If _unit_ is not *undefined* and _currency_ is not *undefined, throw a *RangeError* exception.
-          1. If _currency_ is not *undefined*, set _currency_ to the ASCII-uppercase of _currency_.
-          1. If _unit_ is not *undefined*, set _unit_ to the ASCII-lowercase of _unit_.
-          1. Return the Record { [[Currency]]: _currency_, [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[SignificantDigits]]: _significantDigits, [[Units]]: _unit_ }.
+          1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[SignificantDigits]]: _significantDigits, [[Units]]: _unit_ }.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -285,7 +280,6 @@ location: https://github.com/tc39/proposal-measure/
         1. Let _validatedOpts_ be ? GetAmountOptions(_opts_).
         1. If _parseResult_ is a List of errors, throw a *SyntaxError* exception.
         1. Let _amountValue_ be ? StringDecimalValue of _parseResult_.
-        1. Let _currency_ be _validatedOpts_.[[Currency]].
         1. Let _fractionDigits_ be _validatedOpts_.[[FractionDigits]].
         1. Let _roundingMode_ be _validatedOpts_.[[RoundingMode]].
         1. Let _significantDigits_ be _validatedOpts_.[[SignificantDigits]].
@@ -304,12 +298,11 @@ location: https://github.com/tc39/proposal-measure/
           1. Set _roundedValue_ be RoundToSignificantDigits(_amountValue_, _significantDigits_, _roundingMode_).
           1. Let _digitStr_ be the unique decimal string representation of _roundedValue_ without leading zeroes.
           1. Set _fractionDigits_ to CountFractionDigits(_digitStr_).
-        1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[Currency]], [[FractionDigits]], [[SignificantDigits]], [[Unit]], [[Value]] »).
+        1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[FractionDigits]], [[SignificantDigits]], [[Unit]], [[Value]] »).
         1. Set _O_.[[Value]] to _roundedValue_.
         1. Set _O_.[[SignificantDigits]] to _significantDigits_.
         1. Set _O_.[[FractionDigits]] to _fractionDigits_.
         1. If _unit_ is not *undefined*, set _O_.[[Unit]] to _unit_.
-        1. If _currency_ is not *undefined*, set _O_.[[Currency]] to _currency_.
         1. Return _O_.
       </emu-alg>
       <emu-note>
@@ -365,7 +358,7 @@ location: https://github.com/tc39/proposal-measure/
 
   <emu-clause id="sec-amount.prototype.tostring">
     <h1>Amount.prototype.toString ( [ _options_ ] )</h1>
-    <p>This method returns a String value that renders the underlying mathematical value according to its precision, as well as any unit or currency indicators, if present.</p>
+    <p>This method returns a String value that renders the underlying mathematical value according to its precision, as well as a unit indicator, if present.</p>
     <p>It performs the following steps when called:</p>
     <emu-alg>
       1. Let _O_ be the *this* value.
@@ -373,20 +366,16 @@ location: https://github.com/tc39/proposal-measure/
       1. Perform ? RequireInternalSlot(_O_, [[FractionDigits]]).
       1. Let _processedOptions_ be ? GetOptionsObject(_options_).
       1. Let _displayUnit_ be ? GetOption(_processedOptions_, *"displayUnit"*, ~string~, « *"always"*, *"auto"*, *"never"* », *"auto"*).
-      1. Let _c_ be _O_.[[Currency]].
       1. Let _u_ be _O_.[[Unit]].
       1. Let _v_ be _O_.[[Value]].
       1. Let _fractionDigits_ be _O_.[[FractionDigits]].
       1. Let _s_ be RenderMVWithFractionDigits(_v_, _fractionDigits_).
-      1. If _u_ is *undefined* and _c_ is *undefined*, then
-        1. If _displayUnit_ is *"always"*, return the string concatenation of _s_, *"["*, *"1"*, and *"]"*.
+      1. If _displayUnit_ is *"never"*, return _s_.
+      1. If _u_ is *undefined*, then
+        1. If _displayUnit_ is *"always"*, return the string-concatenation of _s_ and *"[1]"*.
         1. Else, return _s_.
-      1. Else if _u_ is *undefined*, then
-        1. If _displayUnit_ is *"never"*, return _s_.
-        1. Else, return the string concatenation of _s_, *"["*, _c_, and *"]"*.
       1. Else,
-        1. If _displayUnit_ is *"never"*, return _s_.
-        1. Else, return the string concatenation of _s_, *"["*, _u_, and *"]"*.
+        1. Return the string concatenation of _s_, *"["*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 
@@ -403,30 +392,21 @@ location: https://github.com/tc39/proposal-measure/
     <p>It performs the following steps when called:</p>
     <emu-alg>
       1. Let _O_ be the *this* value.
-      1. Perform ? RequireInternalSlot(_O_, [[Currency]]).
       1. Perform ? RequireInternalSlot(_O_, [[Unit]]).
       1. Perform ? RequireInternalSlot(_O_, [[Value]]).
       1. Let _processedOptions_ be ? GetAmountOptions(_options_).
       1. Let _unit_ be _processedOptions_.[[Unit]].
-      1. Let _currency_ be _processedOptions_.[[Currency]].
       1. Let _fractionDigits_ be _processedOptions_.[[FractionDigits]].
       1. Let _significantDigits_ be _processedOptions_.[[SignificantDigits]].
       1. Let _value_ be _O_.[[Value]].
       1. If _fractionDigits_ is not *undefined*, set _value_ to RoundToFractionDigits(_value_, _fractionDigits_).
       1. Else if _significantDigits_ is not *undefined*, set _value_ to RoundToSignificantDigits(_value_, _significantDigits_).
       1. Otherwise, throw a *TypeError* exception.
-      1. Let _N_ be OrdinaryObjectCreate(*"%Amount.prototype%"*, « [[Currency]], [[FractionDigits]], [[SignificantDigits]], [[Unit]], [[Value]] »).
-      1. If _unit_ is not *undefined*, then
-        1. If _O_.[[Currency]] is not *undefined*, throw a *TypeError* exception.
-        1. If _O_.[[Unit]] is *undefined*, throw a *TypeError* exception.
-        1. If _unit_ is not string equal to _O_.[[Unit]], throw a *TypeError* exception.
-      1. If _currency_ is not *undefined*, then
-        1. If _O_.[[Unit]] is not *undefined*, throw a *TypeError* exception.
-        1. If _O_.[[Currency]] is *undefined*, throw a *TypeError* exception.
-        1. If _currency_ is not string equal to _O_.[[Currency]], throw a *TypeError* exception.
+      1. Let _N_ be OrdinaryObjectCreate(*"%Amount.prototype%"*, « [[FractionDigits]], [[SignificantDigits]], [[Unit]], [[Value]] »).
+      1. If _unit_ is not *undefined* and _O_.[[Unit]] is not *undefined*, then
+        1. If SameValueNonNumber(_unit_, _O_.[[Unit]]) is *false*, throw a *TypeError* exception.
       1. Set _N_.[[Value]] to _value_.
       1. Set _N_.[[Unit]] to _unit_.
-      1. Set _N_.[[Currency]] to _currency_.
       1. Set _N_.[[FractionDigits]] to ℝ(_fractionDigits_).
       1. Set _N_.[[SignificantDigits]] to ℝ(_significantDigits_).
       1. Return _N_.
@@ -442,18 +422,16 @@ location: https://github.com/tc39/proposal-measure/
       1. Perform ? RequireInternalSlot(_O_, [[Value]]).
       1. Perform ? RequireInternalSlot(_O_, [[FractionDigits]]).
       1. Perform ? RequireInternalSlot(_O_, [[Unit]]).
-      1. Perform ? RequireInternalSlot(_O_, [[Currency]]).
       1. If _hint_ is not in « *"default"*, *"number"*, *"string"* », throw a *RangeError* exception.
+      1. Let _unit_ be _O_.[[Unit]].
       1. Let _mv_ be _O_.[[Value]].
       1. If _hint_ is *"string"*, then
         1. Let _fractionDigits_ be _O_.[[FractionDigits]].
         1. Let _str_ be RenderMVWithFractionDigits(_mv_, _fractionDigits_).
-        1. If _O_.[[Unit]] is *undefined* and _O_.[[Currency]] is *undefined*, return _str_.
-        1. Else if _O_.[[Unit]] is *undefined*, return the string concatenation of _str_, *"["*, _O_.[[Currency]], and *"]"*.
-        1. Otherwise, return the string concatenation of _str_, *"["*, _O_.[[Unit]], and *"]"*.
+        1. If _unit_ is *undefined*, return _str_.
+        1. Else, return the string concatenation of _str_, *"["*, _unit_, and *"]"*.
       1. Else,
-        1. If _O_.[[Unit]] is not *undefined*, throw a *TypeError* exception.
-        1. If _O_.[[Currency]] is not *undefined*, throw a *TypeError* exception.
+        1. If _unit_ is not *undefined*, throw a *TypeError* exception.
         1. Return the Number value for _mv_.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
Fixes #36 by dropping the `currency` option. It's left in the Intl mathematical value, as that'll need slightly special treatment, and the Intl side of things needs to be properly rebased on top of the [keep-trailing-zeros](https://github.com/tc39/proposal-intl-keep-trailing-zeros) proposal in any case.

CC @gibson042, @sffc